### PR TITLE
fix: multiple callback calls on selection

### DIFF
--- a/src/components/sparqlGraph/SparqlGraph.tsx
+++ b/src/components/sparqlGraph/SparqlGraph.tsx
@@ -30,7 +30,7 @@ export const SparqlGraph = ({ turtleString, layoutName, onElementsSelected }: Sp
 
 	useEffect(() => {
 		cy &&
-			cy.on('select unselect', () => {
+			cy.on('select', () => {
 				onElementsSelected(
 					new RdfSelection(
 						cy.$('node:selected').map((n) => new RdfIndividual(n.data('id'))),


### PR DESCRIPTION
the unselect event triggers when we change selection. Only need a single
call.