### PR TITLE
fix: undefined values in rdftriple

### DIFF
--- a/src/components/sparqlGraph/SparqlGraph.tsx
+++ b/src/components/sparqlGraph/SparqlGraph.tsx
@@ -7,6 +7,7 @@ import { useCytoscapeHelpers } from '../../hooks';
 import { ElementDefinition } from 'cytoscape';
 import CytoscapeComponent from 'react-cytoscapejs';
 import { RdfIndividual, RdfSelection, RdfTriple } from '../../models';
+import { rdfObjectKey, rdfPredicateKey, rdfSubjectKey } from './cytoscapeDataKeys';
 
 export const SparqlGraph = ({ turtleString, layoutName, onElementsSelected }: SparqlGraphProps) => {
 	const layouts: LayoutWrapper[] = [
@@ -34,7 +35,7 @@ export const SparqlGraph = ({ turtleString, layoutName, onElementsSelected }: Sp
 				onElementsSelected(
 					new RdfSelection(
 						cy.$('node:selected').map((n) => new RdfIndividual(n.data('id'))),
-						cy.$('edge:selected').map((n) => new RdfTriple(n.data('rdfSubject'), n.data('rdfPredicate'), n.data('rdfObject')))
+						cy.$('edge:selected').map((n) => new RdfTriple(n.data(rdfSubjectKey), n.data(rdfPredicateKey), n.data(rdfObjectKey)))
 					)
 				);
 			});

--- a/src/components/sparqlGraph/cytoscapeDataKeys.ts
+++ b/src/components/sparqlGraph/cytoscapeDataKeys.ts
@@ -1,0 +1,3 @@
+export const rdfSubjectKey: string = 'rdfSubject';
+export const rdfPredicateKey: string = 'rdfPredicate';
+export const rdfObjectKey: string = 'rdfObject';

--- a/src/utils/cytoscapeMapping.ts
+++ b/src/utils/cytoscapeMapping.ts
@@ -1,5 +1,6 @@
 import { ElementDefinition } from 'cytoscape';
 import { nanoid } from 'nanoid';
+import { rdfObjectKey, rdfPredicateKey, rdfSubjectKey } from '../components/sparqlGraph/cytoscapeDataKeys';
 
 import { useNodeHelpers } from '../mapper';
 import { RdfTriple } from '../models';
@@ -15,26 +16,31 @@ export const useMappers = () => {
 	};
 
 	const cytoscapeEdgeId2Edge = (edgeElement: ElementDefinition): RdfTriple => {
-		return new RdfTriple(edgeElement.data.source, edgeElement.data.predicate, edgeElement.data.target);
+		return new RdfTriple(edgeElement.data[rdfSubjectKey], edgeElement.data[rdfPredicateKey], edgeElement.data[rdfObjectKey]);
 	};
 
 	const cytoscapeEdges2CytoscapeNodes = (cytoscapeEdges: ElementDefinition[]): ElementDefinition[] => {
 		return cytoscapeEdges
-			.flatMap((e) => [e.data.target, e.data.source])
+			.flatMap((e) => [e.data[rdfSubjectKey], e.data[rdfObjectKey]])
 			.filter(onlyUnique)
 			.map(uri2Node);
 	};
 
 	const edge2CytoscapeEdge = (triple: RdfTriple): ElementDefinition => {
-		return {
+		let edgeElement: ElementDefinition = {
 			data: {
-				id: nanoid(),
 				source: triple.rdfSubject,
 				target: triple.rdfObject,
-				predicate: triple.rdfPredicate,
+				id: nanoid(),
 				label: short(triple.rdfPredicate),
 			},
 		};
+
+		edgeElement.data[rdfSubjectKey] = triple.rdfSubject;
+		edgeElement.data[rdfPredicateKey] = triple.rdfPredicate;
+		edgeElement.data[rdfObjectKey] = triple.rdfObject;
+
+		return edgeElement;
 	};
 
 	return [edges2ElementDefinitions, cytoscapeEdgeId2Edge] as const;


### PR DESCRIPTION
Undefined values in rdfTriple in selection callback. Added
cytoscapeDataKeys to make code more robust against these errors in the
future. We might want to add even stronger typing to this in the future,
but it is nontrivial as cytoscape is js library that already has
semi-useful typescript library with ElementDefinition that contains
data-property with source, target and id members. The problem is that
the rest of the data object is untyped so we can use it however we want.
Someone with good typescript skills can propbably fix this in way that
let us keep cytoscapes typing and flexibility, but let us use types to
protect us from certain bugs like this.