### PR TITLE
fix: memory leak when clicking nodes and edges

### DIFF
--- a/src/components/sparqlGraph/SparqlGraph.tsx
+++ b/src/components/sparqlGraph/SparqlGraph.tsx
@@ -46,6 +46,7 @@ export const SparqlGraph = ({ turtleString, layoutName, uiConfig, onElementsSele
 					)
 				);
 			});
+		// TODO: update on onElementsSelected callback change?
 	}, [cy]);
 
 	useEffect(() => {


### PR DESCRIPTION
I messed up and pushed this to master https://github.com/equinor/sparql-graph/commit/97fd2c932825464abb35f90b4d046e5bcd1814c1 earlier. Bump version failed: https://github.com/equinor/sparql-graph/runs/5985284088?check_suite_focus=true

Created this pull request to bump package.
