### PR TITLE
feat: crud for sparqlgraph

### DIFF
--- a/src/components/sparqlGraph/SparqlGraph.stories.tsx
+++ b/src/components/sparqlGraph/SparqlGraph.stories.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import { SparqlGraph } from './SparqlGraph';
-import { RdfSelection } from '../../models';
+import { StoryWrapper } from './StoryWrapper';
 
 export default {
 	title: 'Graph',
-	component: SparqlGraph,
+	component: StoryWrapper,
 	decorators: [(Story) => <div>{Story()}</div>],
 	argTypes: {
 		turtleString: { control: { type: 'text' } },
 		layoutName: { control: { type: 'inline-radio' } },
 	},
-} as ComponentMeta<typeof SparqlGraph>;
+} as ComponentMeta<typeof StoryWrapper>;
 
-const Template: ComponentStory<typeof SparqlGraph> = ({ ...args }) => (
+const Template: ComponentStory<typeof StoryWrapper> = ({ ...args }) => (
 	<>
-		<SparqlGraph {...args} />
+		<StoryWrapper {...args} />
 	</>
 );
 
@@ -69,8 +68,7 @@ example:2a  rdfs:label  "test2a" ;
 
 Example.args = {
 	turtleString: storyTurtle,
-	layoutName: 'Cola',
-	onElementsSelected: (selection: RdfSelection) => console.log(selection),
+	layoutName: 'Cose-Bilkent',
 };
 
 Example.storyName = 'Graph';

--- a/src/components/sparqlGraph/SparqlGraph.types.ts
+++ b/src/components/sparqlGraph/SparqlGraph.types.ts
@@ -1,4 +1,5 @@
 import { LayoutOptions } from 'cytoscape';
+import { RdfPatch } from '../../models';
 import { RdfSelection } from '../../models/rdfSelection';
 
 export type LayoutProps = 'Cola' | 'Cose-Bilkent' | 'Dagre';
@@ -7,6 +8,7 @@ export type SparqlGraphProps = {
 	layoutName: LayoutProps;
 	uiConfig?: UiConfigProps;
 	turtleString: string;
+	patches: RdfPatch[];
 	onElementsSelected: (selection: RdfSelection) => void;
 };
 

--- a/src/components/sparqlGraph/StoryWrapper.tsx
+++ b/src/components/sparqlGraph/StoryWrapper.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@equinor/eds-core-react';
+import { useEffect, useState } from 'react';
+import { RdfPatch, RdfSelection, RdfTriple } from '../../models';
+import { SparqlGraph } from './SparqlGraph';
+import { LayoutProps } from './SparqlGraph.types';
+
+export type SparqlWrapperProps = {
+	turtleString: string;
+	layoutName: LayoutProps;
+};
+
+window.document.addEventListener('keypress', () => 'HELLO???');
+window.document.addEventListener('keydown', () => 'HELLO???');
+window.document.addEventListener('keyup', () => 'HELLO???');
+
+export const StoryWrapper = ({ turtleString, layoutName }: SparqlWrapperProps) => {
+	const dummyNode = 'NewNode';
+	const colors = ['blue', 'green', 'red', 'yellow', 'purple', 'pink', 'cyan', 'grey'];
+
+	const [selection, setSelection] = useState<RdfSelection>(new RdfSelection([], []));
+
+	const [patches, setPatches] = useState<Array<RdfPatch>>([]);
+
+	const deleteSelection = () => {
+		const newPatch = new RdfPatch({ tripleRemovals: selection.rdfTriple, individualRemovals: selection.individuals });
+		let newPatches = [...patches, newPatch];
+		setPatches(newPatches);
+	};
+
+	const onElementsSelected = (selection: RdfSelection): void => {
+		setSelection(selection);
+		if (selection.individuals.length > 0) {
+			const selectedNode = selection.individuals[0].iri;
+			let newPatch: RdfPatch;
+			if (selectedNode === dummyNode) {
+				const randomColor = colors[Math.floor(Math.random() * colors.length)];
+				newPatch = new RdfPatch({ tripleAdditions: [new RdfTriple(selectedNode, 'http://rdf.equinor.com/ui/color', randomColor)] });
+			} else {
+				newPatch = new RdfPatch({
+					tripleAdditions: [
+						new RdfTriple(selectedNode, 'NewPredicate', 'NewNode'),
+						new RdfTriple('NewNode', 'http://www.w3.org/2000/01/rdf-schema#label', 'New cool node. Tap for random color'),
+					],
+				});
+			}
+			let newPatches = [...patches, newPatch];
+			setPatches(newPatches);
+		}
+	};
+
+	return (
+		<div>
+			<Button onClick={deleteSelection}> Delete selection </Button>
+			<SparqlGraph turtleString={turtleString} layoutName={layoutName} patches={patches} onElementsSelected={onElementsSelected} />
+		</div>
+	);
+};

--- a/src/mapper/rdfTriples2Elements.ts
+++ b/src/mapper/rdfTriples2Elements.ts
@@ -10,35 +10,11 @@ const nodeTypePredicate = 'http://rdf.equinor.com/raw/stid/JSON_PIPELINE#tagType
 const labelPredicate = 'http://www.w3.org/2000/01/rdf-schema#label';
 const colorPredicate = 'http://rdf.equinor.com/ui/color';
 
-const parentDisplayEdge = new DisplayControllingPredicate(
-	compoundNodePredicate,
-	'parent',
-	true,
-	(o) => o,
-	() => ''
-);
-const iconDisplayEdge = new DisplayControllingPredicate(
-	nodeTypePredicate,
-	'image',
-	false,
-	(o) => node2ImageUri(o),
-	() => defaultUri
-);
-const labelDisplayEdge = new DisplayControllingPredicate(
-	labelPredicate,
-	'label',
-	false,
-	(o) => o,
-	(s) => short(s)
-);
+const parentDisplayEdge = new DisplayControllingPredicate(compoundNodePredicate, 'parent', true, (o) => o);
+const iconDisplayEdge = new DisplayControllingPredicate(nodeTypePredicate, 'image', false, (o) => node2ImageUri(o));
+const labelDisplayEdge = new DisplayControllingPredicate(labelPredicate, 'label', false, (o) => o);
 
-const colorEdge = new DisplayControllingPredicate(
-	colorPredicate,
-	'color',
-	false,
-	(o) => o,
-	() => undefined
-);
+const colorEdge = new DisplayControllingPredicate(colorPredicate, 'color', false, (o) => o);
 
 const displayEdges = [parentDisplayEdge, iconDisplayEdge, labelDisplayEdge, colorEdge];
 
@@ -70,12 +46,11 @@ export const rdfTriples2Elements = (edges: RdfTriple[]) => {
 		.filter(onlyUnique)
 		.map((n) => {
 			const cyNode: ElementDefinition = { data: { id: n } };
-			displayEdges.forEach(({ predicate, dataProperty, fallback }) => {
-				let value = displayPredicate2UiEdges[predicate].find(({ from }) => from === n)?.to;
-				if (value === undefined) {
-					value = fallback(n);
+			displayEdges.forEach(({ predicate, dataProperty }) => {
+				const value = displayPredicate2UiEdges[predicate].find(({ from }) => from === n)?.to;
+				if (value) {
+					cyNode.data[dataProperty] = value;
 				}
-				cyNode.data[dataProperty] = value;
 			});
 			return cyNode;
 		});

--- a/src/models/displayControllingPredicate.ts
+++ b/src/models/displayControllingPredicate.ts
@@ -1,21 +1,13 @@
 export class DisplayControllingPredicate {
-	constructor(
-		predicate: string,
-		location: string,
-		keepNode: boolean,
-		mapping: (originalObject: string | undefined) => string | undefined,
-		fallback: (originalSubject: string | undefined) => string | undefined
-	) {
+	constructor(predicate: string, location: string, keepNode: boolean, mapping: (originalObject: string | undefined) => string | undefined) {
 		this.predicate = predicate;
 		this.dataProperty = location;
 		this.keepNode = keepNode;
 		this.mapping = mapping;
-		this.fallback = fallback;
 	}
 
 	predicate: string;
 	dataProperty: string;
 	keepNode: boolean;
 	mapping: (originalObject: string | undefined) => string | undefined;
-	fallback: (originalSubject: string | undefined) => string | undefined;
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,3 +5,4 @@ export * from './data';
 export * from './rdfTriple';
 export * from './rdfIndividual';
 export * from './rdfSelection';
+export * from './rdfPatch';

--- a/src/models/rdfPatch.ts
+++ b/src/models/rdfPatch.ts
@@ -1,0 +1,25 @@
+import { RdfIndividual } from './rdfIndividual';
+import { RdfTriple } from './rdfTriple';
+
+export class RdfPatch {
+	tripleAdditions: RdfTriple[];
+	tripleRemovals: RdfTriple[];
+	individualAdditions: RdfIndividual[];
+	individualRemovals: RdfIndividual[];
+	constructor({
+		tripleAdditions = [],
+		tripleRemovals = [],
+		individualAdditions = [],
+		individualRemovals = [],
+	}: {
+		tripleAdditions?: RdfTriple[];
+		tripleRemovals?: RdfTriple[];
+		individualAdditions?: RdfIndividual[];
+		individualRemovals?: RdfIndividual[];
+	}) {
+		this.tripleAdditions = tripleAdditions;
+		this.tripleRemovals = tripleRemovals;
+		this.individualAdditions = individualAdditions;
+		this.individualRemovals = individualRemovals;
+	}
+}

--- a/src/models/rdfPatches.ts
+++ b/src/models/rdfPatches.ts
@@ -1,0 +1,18 @@
+import { RdfPatch } from './rdfPatch';
+
+export class RdfPatches {
+	currentPatch: number;
+	renderedPatch: number;
+	patches: RdfPatch[];
+
+	constructor() {
+		this.currentPatch = 0;
+		this.renderedPatch = 0;
+		this.patches = [];
+	}
+
+	add(patch: RdfPatch) {
+		this.patches.push(patch);
+		this.currentPatch++;
+	}
+}


### PR DESCRIPTION
We can now create, update and delete nodes. Together with callback
functionality the client should be flexible enough to handle a lot of
use cases.

Demostrated most of this code in StoryWrapper.tsx and together with code
in SparqlGraph.stories.tsx it makes up all client code required to make
the example we get from `npm run dev`

When updating nodes we merge data properties from new and old cytoscape
element. New values always override old values if both are set. For this
to work we cannot specify properties like "image" and "label" to
`undefined` we must instead not set the properties at all.  Also removed
default values since we cannot let new nodes override sensible values.
This means we need to be disiplined at setting values like rdfs:label.